### PR TITLE
Fix some issues with unit extraction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: doseminer
 Type: Package
 Title: Extract Drug Dosages from Free-Text Prescriptions
-Version: 0.1.2
+Version: 0.1.3.9000
 Authors@R:
   c(person(given = 'David',
            family = 'Selby',
            role = c('aut', 'cre'),
-           email = 'david.selby@manchester.ac.uk',
+           email = 'david_antony.selby@dfki.de',
            comment = c(ORCID = '0000-0001-8026-5663')),
     person(given = 'Belay Birlie',
            family = 'Yimer',

--- a/R/extract.R
+++ b/R/extract.R
@@ -132,8 +132,11 @@ extract_from_prescription <- function(txt) {
     str_squish
 
   numeric_range <- '(?:\\d+[.]?\\d* - )?\\d+[.]?\\d*(?: (?:x|-) \\d+[.]?\\d*)?'
-
+  
   dose <- output %>%
+    # Remove first mention of units, in case of ranges:
+    str_remove(sprintf('(?<=\\d) ?(?:%s)', paste(drug_units, collapse = '|'))) %>%
+    str_replace('(?<=\\d)/(?=\\d)', ' - ') %>%
     str_extract(sprintf('^%s(?: (?:%s))?|%s(?: (?:%s)|$)',
                         numeric_range, paste(drug_units, collapse = '|'),
                         numeric_range, paste(drug_units, collapse = '|'))

--- a/R/numbers.R
+++ b/R/numbers.R
@@ -305,7 +305,7 @@ latin_medical_terms <- c(
   bid = 'twice daily',
   bis = 'twice',
   biw = 'twice weekly',
-  `tds?` = 'thrice daily',
+  `\\btds?` = 'thrice daily',
   tiw = 'thrice weekly',
   tid = 'thrice daily',
   `alt h(?:or)?` = 'every 2 hours',

--- a/R/units.R
+++ b/R/units.R
@@ -20,7 +20,7 @@ drug_units <- c(
   `sachets?` = "sachet",
   `pastilles?` = "pastille",
   `pills?` = "pill",
-  `dr(?:o?ps?)?` = "drop",
+  `\\bdr(?:o?ps?)?` = "drop",
   `puff?s?` = "puff",
   `blisters?` = "blister",
   `spr(?:ays?)?\\b` = "spray",
@@ -54,7 +54,8 @@ drug_units <- c(
 #' @importFrom stringr str_replace_all str_extract
 extract_dose_unit <- function(txt) {
   standardised <- stringr::str_replace_all(txt, drug_units)
-  stringr::str_extract(standardised, paste(drug_units, collapse = '|'))
+  stringr::str_extract(standardised,
+                       paste0('\\b(?:', paste(drug_units, collapse = '|'), ')\\b'))
 }
 
 #' Evaluate a multiplicative plaintext expression

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,0 +1,23 @@
+context('Text mining miscellaneous highlighted examples')
+
+example1 <- 'Diclofenac sodium 50mg gastro-resistant tablets'
+example2 <- 'Bendroflumethiazide 2.5mg tablets'
+example3 <- 'Co-amoxiclav 250mg/125mg tablets'
+example4 <- 'Zyban 150mg modified-release tablets (GlaxoSmithKline UK Ltd)'
+
+test_that('Do not parse unit abbreviations in middle of words', {
+    out1 <- extract_from_prescription(example1)
+    out2 <- extract_from_prescription(example2)
+    expect_equal(out1$unit, 'milligram') # not 'iu'
+    expect_equal(out2$unit, 'milligram') # not 'drop'
+})
+
+test_that('Handle multiple doses separated by slashes', {
+    out3 <- extract_from_prescription(example3)
+    expect_equal(out3$dose, '250-125')
+})
+
+test_that('Do not parse frequency abbreviations in middle of words', {
+    out4 <- extract_from_prescription(example4)
+    expect_equal(out4$freq, NA_character_) # not '3' (= t.d.)
+})


### PR DESCRIPTION
Made a few changes to avoid some accuracy issues:

- avoid unit abbreviations from getting extracted from the middle of words
- avoid Latin terms from getting extracted from the middle of words
- handle ranges of units where both bounds are specified (e.g. 125mg/250mg)

Fixes #2
